### PR TITLE
[hotfix] Isolate inference service from gateway to avoid timeout

### DIFF
--- a/inference/providers.py
+++ b/inference/providers.py
@@ -67,15 +67,10 @@ class HuggingFaceInferenceProvider(BaseInferenceProvider):
             AutoModelForImageTextToText,
             AutoTokenizer,
         )
-        from transformers.utils.quantization_config import BitsAndBytesConfig
 
         # Model configuration
+        # NOTE: Does not need quantization_config because saved models already have one
         model_kwargs = get_model_device_config()
-        model_kwargs["quantization_config"] = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_use_double_quant=True,
-            bnb_4bit_quant_type="nf4",
-        )
 
         # Load appropriate model class based on base model
         if base_model_id in ["google/gemma-3-1b-it", "google/gemma-3-1b-pt"]:


### PR DESCRIPTION
this issue cannot be fixed as described in #45 so we need a temporary solution

Will revert / find a workaround once #45 is being worked on. this allows us to at least use the service proper for now. 

**NOTE: This is completely functional! Everything like authentication, user scoping, inference framework itself, etc. is fully functional! It only separates the service from the gateway to avoid the timeout.**