### PR TITLE
[feat] Upgrade vision dataset handling to match TRL 0.22.0 native collators

### DIFF
--- a/jobs/training-job/providers.py
+++ b/jobs/training-job/providers.py
@@ -1,6 +1,5 @@
 import logging
 import torch
-import io
 from typing import Any, Tuple
 from datasets import Dataset
 
@@ -191,25 +190,29 @@ def _build_shared_training_args(
 
 def _reformat_vision_dataset(example):
     """
-    Convert vision datasets from complete ChatML format to the format expected by GRPO/DPO/ORPO trainers.
-    This extracts images to a separate column and applies chat template to create prompt strings.
-    This can also be done by formatting dataset differently in preprocessing, but post-processing is what we've chosen.
+    Convert vision datasets from ChatML format to the format expected by GRPO/DPO/ORPO trainers.
 
-    NOTE: We do NOT recommend using SFTTrainer with this YET due to multi-image support requiring data collator!!!
-
-    NOTE: This is used now because we have not completely migrated all datasets to this new format.
-    This is under work and once it's done we no longer need to reformat here.
+    With the new format, images are already in a separate 'images' field, so this is much simpler.
+    For backward compatibility, also handles the old format where images were embedded in content.
 
     Automatically detects format:
-    - Prompt-only format (for GRPO): {"prompt": [...], "answer": "...", "reasoning": "...", ...}
-      Output: {"prompt": "templated_string", "image": PIL.Image, "answer": "...", "reasoning": "...", ...}
+    - Language modeling format (for SFT): {"messages": [...]}
+      Output: {"messages": [...], "images": [PIL.Image], ...}
+
+    - Prompt-only format (for GRPO): {"prompt": [...], "answer": "...", ...}
+      Output: {"prompt": "templated_string", "image": PIL.Image, "answer": "...", ...}
 
     - Preference format (for DPO/ORPO): {"prompt": [...], "chosen": [...], "rejected": [...]}
       Output: {"prompt": "templated_string", "chosen": "templated_string", "rejected": "templated_string", "images": [PIL.Image]}
     """
     from PIL import Image
 
-    def get_images_from_prompt(prompt_messages):
+    # new format does not need to reformat, works directly with trainers' default collator
+    if "images" in example and example["images"]:
+        return example
+
+    def get_images_from_content_legacy(prompt_messages):
+        """Legacy function to extract images from old format content items (backward compatibility)."""
         image_list = []
         if not isinstance(prompt_messages, list):
             return image_list
@@ -227,33 +230,23 @@ def _reformat_vision_dataset(example):
                     isinstance(content_part, dict)
                     and content_part.get("type") == "image"
                 ):
+                    # Old format: check for embedded image data
                     image_data = content_part.get("image")
                     if isinstance(image_data, Image.Image):
                         image_list.append(image_data.convert("RGB"))
-                    elif isinstance(image_data, dict) and "bytes" in image_data:
-                        img_bytes = image_data["bytes"]
-                        if isinstance(img_bytes, (bytes, bytearray)):
-                            try:
-                                pil_img = Image.open(io.BytesIO(img_bytes))
-                                image_list.append(pil_img.convert("RGB"))
-                            except Exception:
-                                # Ignore corrupted images
-                                pass
+                    # Note: HF format conversion now handled in storage.py during dataset loading
         return image_list
 
     if all(k in example for k in ("prompt", "chosen", "rejected")):
-        # in DPOTrainer/ORPOTrainer._prepare_dataset the _process_row requires the "images" field
-        # It then handles all chat template and tokenization automatically for all three columns
-        # see trl.maybe_apply_chat_template for details
-        example["images"] = get_images_from_prompt(example.get("prompt"))
+        example["images"] = get_images_from_content_legacy(example.get("prompt"))
+    elif "messages" in example:
+        example["images"] = get_images_from_content_legacy(example.get("messages"))
     elif "prompt" in example:
-        # GRPOTrainer._generate_and_score_completions will look for "image", then apply chat template with tokenization
-        # then it will handle image processing using self.processing_class and the prompt_text:
-        images = get_images_from_prompt(example.get("prompt"))
+        images = get_images_from_content_legacy(example.get("prompt"))
         example["image"] = images[0] if images else None
     else:
         raise ValueError(
-            "Example must contain 'prompt' field (for GRPO) or 'prompt', 'chosen', and 'rejected' fields (for DPO/ORPO)"
+            "Example must contain 'prompt' field (for GRPO) or 'prompt', 'chosen', and 'rejected' fields (for DPO/ORPO) or 'messages' field (for SFT)"
         )
 
     return example
@@ -400,12 +393,17 @@ class HuggingFaceTrainingService(BaseTrainingService):
         Otherwise you should provide a data collator that is used by the trainer to do reformatting internally.
         Or you can provide a formatting_func in the trainer.
         """
-        if modality == "vision" and trainer_type in ["dpo", "grpo", "orpo"]:
-            # Convert vision datasets to the format expected by GRPO/DPO trainers and they will handle processing
-            # NOTE: do not use batching here since it will make each column a list and break the format function
-            train_ds = train_ds.map(lambda example: _reformat_vision_dataset(example))
-            if eval_ds is not None:
-                eval_ds = eval_ds.map(lambda example: _reformat_vision_dataset(example))
+        if modality == "vision":
+            if "images" not in train_ds.column_names:
+                # Backward compatibility with old dataset not saved with "images" columns since TRL 0.22.0
+                # NOTE: do not use batching here since it will make each column a list and break the format function
+                train_ds = train_ds.map(
+                    lambda example: _reformat_vision_dataset(example)
+                )
+                if eval_ds is not None:
+                    eval_ds = eval_ds.map(
+                        lambda example: _reformat_vision_dataset(example)
+                    )
 
         return train_ds, eval_ds
 
@@ -474,6 +472,7 @@ class HuggingFaceTrainingService(BaseTrainingService):
         trainer_type: str,
         cfg: TrainingConfig,
     ) -> Any:
+        # NOTE: TRL trainers now handle vision processing directly!
         # Common trainer arguments
         base_trainer_args = {
             "model": model,
@@ -487,9 +486,9 @@ class HuggingFaceTrainingService(BaseTrainingService):
             # For SFT Trainer we use custom collator to support multiple images and support computing metrics
             return self.SFTTrainer(
                 **base_trainer_args,
-                data_collator=self._create_vision_collate_fn(tokenizer_or_processor)
-                if cfg.modality == "vision"
-                else None,
+                # data_collator=self._create_vision_collate_fn(tokenizer_or_processor)
+                # if cfg.modality == "vision"
+                # else None,
                 compute_metrics=create_compute_metrics(
                     cfg.eval_config.compute_eval_metrics,
                     cfg.eval_config.batch_eval_metrics,
@@ -506,10 +505,8 @@ class HuggingFaceTrainingService(BaseTrainingService):
                 reward_funcs=reward_funcs,
             )
         elif trainer_type == "dpo":
-            # NOTE: DPO Trainer doesn't need collator for vision, we reformat the dataset manually
             return self.DPOTrainer(**base_trainer_args)
         elif trainer_type == "orpo":
-            # NOTE: ORPO uses the same dataset format as DPO (preference pairs)
             return self.ORPOTrainer(**base_trainer_args)
         else:
             raise ValueError(f"Unsupported trainer type: {trainer_type}")
@@ -517,18 +514,21 @@ class HuggingFaceTrainingService(BaseTrainingService):
     def _create_vision_collate_fn(self, processor):
         """
         Create vision collate function for HuggingFace SFT vision training.
-        This ONLY works with SFTTrainer dataset type because GRPO, DPO, and ORPO do not use data collator.
-        They require a pre-formatted dataset and handles vision processing internally.
-        NOTE: There is no built in hugging face vision collator unlike Unsloth
+
+        Simplified for the new format where images are in a separate field.
+        Still supports backward compatibility with the old embedded format.
         """
+        raise DeprecationWarning(
+            "This has been deprecated since TRL >0.22.0 supports DataCollatorForVisionLanguageModeling natively"
+        )
         from PIL import Image
 
         def vision_collate_fn(examples):
             """
-            Collate function for vision datasets that are already in ChatML format with images.
-            1. First apply chat template to all examples in this batch (converts from conversational to standard format)
-            2. Extract images from type:image fields and apply them to processors in the correct order
-            3. Do some postprocessing on the tokens and labels and return the batch with text and images
+            Collate function for vision datasets.
+            1. Apply chat template to convert from conversational to standard format
+            2. Extract images from the separate images field (new format) or from content (old format)
+            3. Process tokens, labels, and images for the batch
             """
             texts = [
                 processor.apply_chat_template(
@@ -539,8 +539,18 @@ class HuggingFaceTrainingService(BaseTrainingService):
                 for example in examples
             ]
 
-            # Extract images from pre-processed ChatML messages
-            def extract_images_from_messages(messages):
+            # Extract images - simplified for new format
+            def extract_images_from_example(example):
+                # New format: images in separate field
+                if "images" in example and example["images"]:
+                    images = []
+                    for img_data in example["images"]:
+                        if isinstance(img_data, Image.Image):
+                            images.append(img_data.convert("RGB"))
+                    return images
+
+                # Old format fallback: extract from content (backward compatibility)
+                messages = example.get("messages", [])
                 images = []
                 for msg in messages:
                     content = msg.get("content", [])
@@ -548,27 +558,11 @@ class HuggingFaceTrainingService(BaseTrainingService):
                         for item in content:
                             if isinstance(item, dict) and item.get("type") == "image":
                                 img_data = item.get("image")
-                                if img_data:
-                                    # Handle PIL Image objects
-                                    if isinstance(img_data, Image.Image):
-                                        images.append(img_data.convert("RGB"))
-                                    # Handle HuggingFace dataset format: {"bytes": ..., "path": null}
-                                    elif (
-                                        isinstance(img_data, dict)
-                                        and "bytes" in img_data
-                                    ):
-                                        image_bytes = img_data["bytes"]
-                                        if isinstance(image_bytes, (bytes, bytearray)):
-                                            pil_image = Image.open(
-                                                io.BytesIO(image_bytes)
-                                            )
-                                            images.append(pil_image.convert("RGB"))
+                                if img_data and isinstance(img_data, Image.Image):
+                                    images.append(img_data.convert("RGB"))
                 return images
 
-            images = [
-                extract_images_from_messages(example["messages"])
-                for example in examples
-            ]
+            images = [extract_images_from_example(example) for example in examples]
 
             # Tokenize texts and process images
             batch = processor(
@@ -737,10 +731,15 @@ class UnslothTrainingService(BaseTrainingService):
                 else None
             )
         # Convert vision datasets to the format expected by GRPO/DPO/ORPO trainers
-        elif modality == "vision" and trainer_type in ["dpo", "grpo", "orpo"]:
-            train_ds = train_ds.map(lambda example: _reformat_vision_dataset(example))
-            if eval_ds is not None:
-                eval_ds = eval_ds.map(lambda example: _reformat_vision_dataset(example))
+        elif modality == "vision":
+            if "images" not in train_ds.column_names:
+                train_ds = train_ds.map(
+                    lambda example: _reformat_vision_dataset(example)
+                )
+                if eval_ds is not None:
+                    eval_ds = eval_ds.map(
+                        lambda example: _reformat_vision_dataset(example)
+                    )
 
         return train_ds, eval_ds
 
@@ -842,6 +841,7 @@ class UnslothTrainingService(BaseTrainingService):
                 **base_trainer_args,
                 data_collator=(
                     # if modality is vision this is processor
+                    # Unsloth vision collator supports the new "images" format for SFT as well
                     self.UnslothVisionDataCollator(model, tokenizer_or_processor)
                     if cfg.modality == "vision"
                     else None

--- a/jobs/training-job/pyproject.toml
+++ b/jobs/training-job/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "huggingface-hub>=0.32.4",
     "peft>=0.14.0",
     "transformers>=4.56.0",
-    "trl>=0.21.0",
+    "trl>=0.22.0",
     "fastapi>=0.104.1",
     "uvicorn[standard]==0.24.0",
     "wandb",

--- a/jobs/training-job/uv.lock
+++ b/jobs/training-job/uv.lock
@@ -454,7 +454,7 @@ requires-dist = [
     { name = "rouge-score" },
     { name = "torch", specifier = ">=2.7.1", index = "https://download.pytorch.org/whl/cu126" },
     { name = "transformers", specifier = ">=4.56.0" },
-    { name = "trl", specifier = ">=0.21.0" },
+    { name = "trl", specifier = ">=0.22.0" },
     { name = "unsloth", specifier = ">=2025.9.1" },
     { name = "unsloth-zoo", specifier = ">=2025.9.1" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.24.0" },
@@ -2003,16 +2003,16 @@ wheels = [
 
 [[package]]
 name = "trl"
-version = "0.21.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accelerate" },
     { name = "datasets" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/bd/f25e4358287d3feabb815106edea902c93b85331beafeca358e28e23ba3a/trl-0.21.0.tar.gz", hash = "sha256:84dec571e47520e64ccedda94623df13e723fbbd689fd80bf524b9eb0b6d6ca8", size = 462967, upload_time = "2025-08-05T16:51:08.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/18/c18e27f6156cf961791ca7abcd4ee5fc8c5ae0fbb936c59827852ee118f5/trl-0.23.0.tar.gz", hash = "sha256:abfe0ecfa6b7e46022552b9dd0cc288bf2c4ef19364ce7765d10218b62b618f1", size = 515765, upload_time = "2025-09-10T04:16:42.377Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/bf/423e0c0b013d33ccbff8ea31ce97ee8211b72ebace1a205ae92dcb67682a/trl-0.21.0-py3-none-any.whl", hash = "sha256:0ac51a49290eb3a188dc187da5bbc95d9edc61395b4a3b4702337dd0cd890e0d", size = 511944, upload_time = "2025-08-05T16:51:07.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/035cace9b8853df794db0499299273abef30de889602587efa2a95c7dccb/trl-0.23.0-py3-none-any.whl", hash = "sha256:bb8f35a6a1531bad2d52032add29380413bd9b032d133ab6df16d2191f14f9e6", size = 564734, upload_time = "2025-09-10T04:16:40.34Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR will completely upgrade the format converter to use the new format documented in the `README.md` in `preprocessing` where we use a separate column for images. This keeps us on the same page as TRL's future directions by moving from embedding images and extracting them for processing to directly using image index for these features.

In greater details, this PR:

- Updates the format converter
- Updates the GET dataset endpoint to handle conversion to base64 for both the new and old format
- Updates dataset download interface for all usage to handle converting `bytes` field to `PIL.Images` due to parquet serialization incompatibilities and the newer versions of datasets
- Updates training job to skip old reformatting logic if the dataset is in the new format and use the default `DataCollatorForVisionlagnuageModeling` from latest TRL SFT and other trainers directly
- Updates inference service with the following assumptions: batch inference only uses base64 from frontend, evaluations loads dataset and converts it to the old format (because embedded images are still expected in the framework backend)

## Notes

This PR attempts to make everything backward compatible.